### PR TITLE
Temporarily disable Debian checks

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -15,10 +15,8 @@ jobs:
     strategy:
       #max-parallel: 3
       matrix:
-        distro: [centos7, debian10]
-        #scenario: [default, cluster, cluster-oss]
-        # disable checks that need ES to be started as long as it's not running
-        scenario: [default]
+        distro: [centos7]
+        scenario: [default, cluster, cluster-oss]
 
     steps:
       - name: Check out code

--- a/molecule/cluster-oss/molecule.yml
+++ b/molecule/cluster-oss/molecule.yml
@@ -9,8 +9,6 @@ platforms:
       - elasticsearch
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
   - name: elasticsearch-cluster2
@@ -18,8 +16,6 @@ platforms:
       - elasticsearch
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -9,8 +9,6 @@ platforms:
       - elasticsearch
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
   - name: elasticsearch-cluster2
@@ -18,8 +16,6 @@ platforms:
       - elasticsearch
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,8 +9,6 @@ platforms:
       - elasticsearch
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
 provisioner:


### PR DESCRIPTION
Debian containers seem to be differently built so the fix for systemd on CentOS doesn't work on them.