### PR TITLE
Make ES data directory moveable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Role Variables
 
 * *elasticsearch_enable*: Start and enable Elasticsearch (default: `true`)
 * *elasticsearch_ca*: Set to the inventory hostname of the host that should house the CA for certificates for inter-node communication. (default: First node in the `elasticsearch` host group)
+* *elasticsearch_datapath*: Path where Elasticsearch will store it's data. (default: `/var/lib/elasticsearch` - the packages default)
+* *elasticsearch_create_datapath*: Create the path for data to store if it doesn't exist. (default: `false` - only useful if you change `elasticsearch_datapath`)
 *elasticsearch_fs_repo*: List of paths that should be registered as repository for snapshots (only filesystem supported so far). (default: none) Remember, that every node needs access to the same share under the same path.
 
 These variables are identical over all our elastic related roles, hence the different naming schemes.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ elasticsearch_monitoring_enabled: true
 elasticsearch_security: true
 elasticsearch_bootstrap_pw: PleaseChangeMe
 elasticsearch_http_security: true
+elasticsearch_datapath: /var/lib/elasticsearch
+elasticsearch_create_datapath: false
 
 # The following variables are to be used when activating security
 # They follow a different naming scheme to show that they are global

--- a/tasks/elasticsearch-security.yml
+++ b/tasks/elasticsearch-security.yml
@@ -27,7 +27,7 @@
   changed_when: false
   register: es_keystore
 
-- name: Cet bootstrap password
+- name: Set bootstrap password
   shell: >
     echo "{{ elasticsearch_bootstrap_pw }}" |
     /usr/share/elasticsearch/bin/elasticsearch-keystore

--- a/tasks/elasticsearch-security.yml
+++ b/tasks/elasticsearch-security.yml
@@ -7,7 +7,7 @@
   tags:
     - certificates
 
-- name: create directory for Elasticsearch CA
+- name: Create directory for Elasticsearch CA
   file:
     path: "{{ elastic_ca_dir }}"
     owner: root
@@ -17,17 +17,17 @@
   tags:
     - certificates
 
-- name: create keystore
+- name: Create keystore
   command: /usr/share/elasticsearch/bin/elasticsearch-keystore create
   args:
     creates: /etc/elasticsearch/elasticsearch.keystore
 
-- name: check for bootstrap password
+- name: Check for bootstrap password
   command: /usr/share/elasticsearch/bin/elasticsearch-keystore list
   changed_when: false
   register: es_keystore
 
-- name: set bootstrap password
+- name: Cet bootstrap password
   shell: >
     echo "{{ elasticsearch_bootstrap_pw }}" |
     /usr/share/elasticsearch/bin/elasticsearch-keystore
@@ -35,9 +35,9 @@
   when: "'bootstrap.password' not in es_keystore.stdout_lines"
   ignore_errors: "{{ ansible_check_mode }}"
 
-- name: create ca and certificates
+- name: Create ca and certificates
   block:
-    - name: configure ca
+    - name: Configure ca
       command: >
         /usr/share/elasticsearch/bin/elasticsearch-certutil ca
         --pass {{ elastic_ca_pass }}
@@ -46,7 +46,7 @@
       args:
         creates: "{{ elastic_ca_dir }}/elastic-stack-ca.p12"
 
-    - name: create individual certificates
+    - name: Create individual certificates
       command: >
         /usr/share/elasticsearch/bin/elasticsearch-certutil cert
         --ca {{ elastic_ca_dir }}/elastic-stack-ca.p12
@@ -60,7 +60,7 @@
       args:
         creates: "{{ elastic_ca_dir }}/{{ hostvars[item].ansible_hostname }}.p12"
 
-    - name: extract CA certificate
+    - name: Extract CA certificate
       command: "openssl pkcs12 -in {{ elastic_ca_dir }}/{{ ansible_hostname }}.p12 -cacerts -nokeys -out {{ elastic_ca_dir }}/ca.crt -password pass:{{ elasticsearch_tls_key_passphrase }}"
       args:
         creates: "{{ elastic_ca_dir }}/ca.crt"
@@ -148,7 +148,7 @@
   changed_when: false
   when: not elasticsearch_passwords_file.stat.exists | bool
 
-- name: fetch Elastic password
+- name: Fetch Elastic password
   shell: grep "PASSWORD elastic" {{ elastic_initial_passwords }} | awk {' print $4 '}
   register: elastic_password
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
     state: directory
     owner: elasticsearch
     group: elasticsearch
-    mode: 2750
+    mode: "2750"
   when: elasticsearch_create_datapath | bool
 
 - name: Start Elasticsearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,15 @@
   tags:
     - security
 
+- name: Create Elasticsearch data directory
+  file:
+    path: "{{ elasticsearch_datapath }}"
+    state: directory
+    owner: elasticsearch
+    group: elasticsearch
+    mode: 2750
+  when: elasticsearch_create_datapath | bool
+
 - name: Start Elasticsearch
   service:
     name: elasticsearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   when: elasticsearch_security | bool
 
 # the following should be done by the rpm but failed with 7.4
-- name: set ulimits for Elasticsearch
+- name: Set ulimits for Elasticsearch
   pam_limits:
     limit_item: nofile
     domain: elasticsearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,7 @@
     - elastic_variant == "elastic"
   tags:
     - security
+    - certificates
 
 - name: Create Elasticsearch data directory
   file:

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -1,5 +1,5 @@
 node.name: "{{ ansible_hostname }}"
-path.data: /var/lib/elasticsearch
+path.data: {{ elasticsearch_datapath }}
 path.logs: /var/log/elasticsearch
 network.host: ["_local_","_site_"]
 discovery.seed_hosts: [ {% for host in groups['elasticsearch']  %}


### PR DESCRIPTION
fixes NETWAYS/ansible-role-elasticsearch#72

Optionally create the new data directory with correct permissions