### PR TITLE
Allow disabling of system call filter checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Role Variables
 * *elasticsearch_enable*: Start and enable Elasticsearch (default: `true`)
 * *elasticsearch_ca*: Set to the inventory hostname of the host that should house the CA for certificates for inter-node communication. (default: First node in the `elasticsearch` host group)
 *elasticsearch_fs_repo*: List of paths that should be registered as repository for snapshots (only filesystem supported so far). (default: none) Remember, that every node needs access to the same share under the same path.
+* *elasticsearch_disable_systemcallfilterchecks*: Disable system call filter checks. This has a security impact but is necessary on some systems. Please refer to the [docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/_system_call_filter_check.html) for details. (default: `false`)
 
 These variables are identical over all our elastic related roles, hence the different naming schemes.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ elasticsearch_monitoring_enabled: true
 elasticsearch_security: true
 elasticsearch_bootstrap_pw: PleaseChangeMe
 elasticsearch_http_security: true
+elasticsearch_disable_systemcallfilterchecks: false
 
 # The following variables are to be used when activating security
 # They follow a different naming scheme to show that they are global

--- a/molecule/cluster-oss/converge.yml
+++ b/molecule/cluster-oss/converge.yml
@@ -5,6 +5,7 @@
   hosts: all
   vars:
     elastic_variant: oss
+    elasticsearch_disable_systemcallfilterchecks: true
   tasks:
     - name: "Include Elastics repos role"
       include_role:

--- a/molecule/cluster/converge.yml
+++ b/molecule/cluster/converge.yml
@@ -3,6 +3,8 @@
 # Found at: https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
 - name: Converge
   hosts: all
+  vars:
+    elasticsearch_disable_systemcallfilterchecks: true
   tasks:
     - name: "Include Elastics repos role"
       include_role:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,7 @@
   vars:
     elasticsearch_enable: false
     elasticsearch_security: false
+    elasticsearch_disable_systemcallfilterchecks: true
   tasks:
     - name: "Include Elastics repos role"
       include_role:

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -11,6 +11,9 @@ cluster.initial_master_nodes: [ {% for host in groups['elasticsearch']  %}
 {% if elastic_temperature is defined %}
 node.attr.temp: "{{ elastic_temperature }}"
 {% endif %}
+{% if elasticsearch_disable_systemcallfilterchecks | bool %}
+bootstrap.system_call_filter: false
+{% endif %}
 {% if elastic_variant == "elastic" %}
 xpack.ml.enabled: {{ elasticsearch_ml_enabled }}
 xpack.monitoring.collection.enabled: {{ elasticsearch_monitoring_enabled }}


### PR DESCRIPTION
fixes #73

These checks have a security impact but you have to disable them on certain hardened systems. The Elasticsearch log will tell you when to disable them.